### PR TITLE
fix: Error 'Uncaught TypeError: a is null' related to toggleHoverState of the index.js

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -68,19 +68,15 @@ contactMeBoxes.forEach(box => {
     let i = box.querySelector("i");
     let a = box.querySelector("a");
 
-    const toggleHoverState = (isHovering) => {
-        if (isHovering) {
-            i.classList.add("bi-copy-hover");
-            box.classList.add("contact-me-box-hover");
-            a.classList.remove("text-decoration-none");
-        } else {
-            i.classList.remove("bi-copy-hover");
-            box.classList.remove("contact-me-box-hover");
-            a.classList.add("text-decoration-none");
+    const toggleHoverState = () => {
+        if(i && box && a){   
+            i.classList.toggle("bi-copy-hover");
+            box.classList.toggle("contact-me-box-hover");
+            a.classList.toggle("text-decoration-none");
         }
     };
-    box.addEventListener("mouseenter", () => toggleHoverState(true));
-    box.addEventListener("mouseleave", () => toggleHoverState(false));
+    box.addEventListener("mouseenter", () => toggleHoverState());
+    box.addEventListener("mouseleave", () => toggleHoverState());
     i.addEventListener("click", () => copyText(box, i));
 });
 


### PR DESCRIPTION
Hi, I have fixed the error mentioned. The issue was in the JavaScript code for the 'Copy to clipboard' functionality. There were no checks to verify whether the variables existed or not. Thank you. I remain attentive.